### PR TITLE
Process synchronization on exit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>redis.embedded</groupId>
     <artifactId>embedded-redis</artifactId>
     <packaging>jar</packaging>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.3-SNAPSHOT</version>
     <name>embedded-redis</name>
     <description>Redis embedded server for Java integration testing</description>
     <url>https://github.com/kstyrc/embedded-redis</url>

--- a/src/main/java/redis/embedded/RedisServer.java
+++ b/src/main/java/redis/embedded/RedisServer.java
@@ -103,13 +103,15 @@ public class RedisServer {
 	private ProcessBuilder createRedisProcessBuilder() {
 		ProcessBuilder pb = new ProcessBuilder(command.getAbsolutePath(), "--port", Integer.toString(port));
 		pb.directory(command.getParentFile());
+		pb.redirectErrorStream();
 
 		return pb;
 	}
 
-	public synchronized void stop() {
+	public synchronized void stop() throws InterruptedException {
 		if (active) {
 			redisProcess.destroy();
+			redisProcess.waitFor();
 			active = false;
 		}
 	}

--- a/src/test/java/redis/embedded/RedisServerTest.java
+++ b/src/test/java/redis/embedded/RedisServerTest.java
@@ -38,11 +38,9 @@ public class RedisServerTest {
 		redisServer.start();
 		redisServer.stop();
 		
-		Thread.sleep(200L);
 		redisServer.start();
 		redisServer.stop();
 		
-		Thread.sleep(200L);
 		redisServer.start();
 		redisServer.stop();
 	}


### PR DESCRIPTION
Wait for process exit before returning from stop(). 
Bump pom due to new signature -- stop() can now throw an InterruptedException. 
Tests don't need to sleep anymore
