### PR TITLE
Throw an exception if redis has not been started.

### DIFF
--- a/src/main/java/redis/embedded/RedisServer.java
+++ b/src/main/java/redis/embedded/RedisServer.java
@@ -194,7 +194,12 @@ public class RedisServer {
 			String outputLine = null;
 			do {
 				outputLine = reader.readLine();
-			} while (outputLine != null && !outputLine.matches(REDIS_READY_PATTERN));
+
+                if (outputLine == null) {
+                    //Something goes wrong. Stream is ended before server was activated.
+                    throw new RuntimeException("Can't start redis server. Check logs for details.");
+                }
+            } while (!outputLine.matches(REDIS_READY_PATTERN));
 		} finally {
 			reader.close();
 		}


### PR DESCRIPTION
It is often confusing when server has not been started, but redis embedded silently ignore that and answer that isActive is true.
