### PR TITLE
Support JDK 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,16 @@ Contributors
  * anthonyu ([@anthonyu](http://github.com/anthonyu))
  * Artem Orobets ([@enisher](http://github.com/enisher))
  * Sean Simonsen ([@SeanSimonsen](http://github.com/SeanSimonsen))
+ * Rob Winch ([@rwinch](http://github.com/rwinch))
 
 
 Changelog
 ==============
 
-### 0.5 
+### 0.6
+ * Support JDK 6 +
+
+### 0.5
  * OS detection fix
  * redis binary per OS/arch pair
  * Updated to 2.8.19 binary for Windows

--- a/pom.xml
+++ b/pom.xml
@@ -100,9 +100,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <compilerVersion>1.8</compilerVersion>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <compilerVersion>1.6</compilerVersion>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
 

--- a/src/main/java/redis/embedded/RedisSentinel.java
+++ b/src/main/java/redis/embedded/RedisSentinel.java
@@ -8,7 +8,7 @@ public class RedisSentinel extends AbstractRedisInstance {
 
     public RedisSentinel(List<String> args, int port) {
         super(port);
-        this.args = new ArrayList<>(args);
+        this.args = new ArrayList<String>(args);
     }
 
     public static RedisSentinelBuilder builder() { return new RedisSentinelBuilder(); }

--- a/src/main/java/redis/embedded/RedisSentinelBuilder.java
+++ b/src/main/java/redis/embedded/RedisSentinelBuilder.java
@@ -143,7 +143,7 @@ public class RedisSentinelBuilder {
     private List<String> buildCommandArgs() {
         Preconditions.checkNotNull(sentinelConf);
 
-        List<String> args = new ArrayList<>();
+        List<String> args = new ArrayList<String>();
         args.add(executable.getAbsolutePath());
         args.add(sentinelConf);
         args.add("--sentinel");

--- a/src/main/java/redis/embedded/RedisServer.java
+++ b/src/main/java/redis/embedded/RedisServer.java
@@ -41,7 +41,7 @@ public class RedisServer extends AbstractRedisInstance {
 
     RedisServer(List<String> args, int port) {
         super(port);
-        this.args = new ArrayList<>(args);
+        this.args = new ArrayList<String>(args);
     }
 
     public static RedisServerBuilder builder() {

--- a/src/main/java/redis/embedded/RedisServerBuilder.java
+++ b/src/main/java/redis/embedded/RedisServerBuilder.java
@@ -106,7 +106,7 @@ public class RedisServerBuilder {
     }
 
     private List<String> buildCommandArgs() {
-        List<String> args = new ArrayList<>();
+        List<String> args = new ArrayList<String>();
         args.add(executable.getAbsolutePath());
 
         if (!Strings.isNullOrEmpty(redisConf)) {

--- a/src/main/java/redis/embedded/ports/PredefinedPortProvider.java
+++ b/src/main/java/redis/embedded/ports/PredefinedPortProvider.java
@@ -9,7 +9,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class PredefinedPortProvider implements PortProvider {
-    private final List<Integer> ports = new LinkedList<>();
+    private final List<Integer> ports = new LinkedList<Integer>();
     private final Iterator<Integer> current;
 
     public PredefinedPortProvider(Collection<Integer> ports) {

--- a/src/main/java/redis/embedded/util/JedisUtil.java
+++ b/src/main/java/redis/embedded/util/JedisUtil.java
@@ -3,9 +3,9 @@ package redis.embedded.util;
 import redis.embedded.Redis;
 import redis.embedded.RedisCluster;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class JedisUtil {
     public static Set<String> jedisHosts(Redis redis) {
@@ -19,6 +19,10 @@ public class JedisUtil {
     }
 
     public static Set<String> portsToJedisHosts(List<Integer> ports) {
-        return ports.stream().map(p -> "localhost:" + p).collect(Collectors.toSet());
+        Set<String> hosts = new HashSet<String>();
+        for(Integer p : ports) {
+            hosts.add("localhost:" + p);
+        }
+        return hosts;
     }
 }

--- a/src/test/java/redis/embedded/RedisClusterTest.java
+++ b/src/test/java/redis/embedded/RedisClusterTest.java
@@ -44,8 +44,12 @@ public class RedisClusterTest {
         instance.stop();
 
         //then
-        sentinels.stream().forEach(s -> verify(s).stop());
-        servers.stream().forEach(m -> verify(m).stop());
+        for(Redis s : sentinels) {
+            verify(s).stop();
+        }
+        for(Redis s : servers) {
+            verify(s).stop();
+        }
     }
 
     @Test
@@ -59,8 +63,12 @@ public class RedisClusterTest {
         instance.start();
 
         //then
-        sentinels.stream().forEach(s -> verify(s).start());
-        servers.stream().forEach(m -> verify(m).start());
+        for(Redis s : sentinels) {
+            verify(s).start();
+        }
+        for(Redis s : servers) {
+            verify(s).start();
+        }
     }
 
     @Test
@@ -78,8 +86,12 @@ public class RedisClusterTest {
         instance.isActive();
 
         //then
-        sentinels.stream().forEach(s -> verify(s).isActive());
-        servers.stream().forEach(m -> verify(m).isActive());
+        for(Redis s : sentinels) {
+            verify(s).isActive();
+        }
+        for(Redis s : servers) {
+            verify(s).isActive();
+        }
     }
 
     @Test

--- a/src/test/java/redis/embedded/ports/EphemeralPortProviderTest.java
+++ b/src/test/java/redis/embedded/ports/EphemeralPortProviderTest.java
@@ -1,48 +1,28 @@
 package redis.embedded.ports;
 
 import org.junit.Test;
-import redis.embedded.exceptions.RedisBuildingException;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 
 public class EphemeralPortProviderTest {
-    private final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     @Test
-    public void nextShouldGiveNextFreeEphemeralPortConcurrently() throws Exception {
+    public void nextShouldGiveNextFreeEphemeralPort() throws Exception {
         //given
+        final int portCount = 20;
         final EphemeralPortProvider provider = new EphemeralPortProvider();
 
         //when
-        final List<Integer> ports = executor.invokeAll(
-                Stream.generate(() -> (Callable<Integer>) provider::next).limit(20).collect(Collectors.toList()))
-                .stream()
-                .map(this::getResult)
-                .sorted()
-                .distinct()
-                .collect(Collectors.toList());
+        final List<Integer> ports = new ArrayList<Integer>();
+        for(int i = 0;i < portCount; i++) {
+            ports.add(provider.next());
+        }
 
         //then
         System.out.println(ports);
         assertEquals(20, ports.size());
     }
-
-    private int getResult(Future<Integer> f) {
-        int ret = 0;
-        try {
-            ret = f.get();
-        } catch (Exception e) {
-            throw new RedisBuildingException("failed to deliver", e);
-        }
-        return ret;
-    }
-
 }

--- a/src/test/java/redis/embedded/ports/PredefinedPortProviderTest.java
+++ b/src/test/java/redis/embedded/ports/PredefinedPortProviderTest.java
@@ -3,35 +3,26 @@ package redis.embedded.ports;
 import org.junit.Test;
 import redis.embedded.exceptions.RedisBuildingException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 
 public class PredefinedPortProviderTest {
-    private final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     @Test
-    public void nextShouldGiveNextPortFromAssignedListConcurrently() throws Exception {
+    public void nextShouldGiveNextPortFromAssignedList() throws Exception {
         //given
         Collection<Integer> ports = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         final PredefinedPortProvider provider = new PredefinedPortProvider(ports);
 
         //when
-        final List<Integer> returnedPorts = executor.invokeAll(
-                Stream.generate(() -> (Callable<Integer>) provider::next).limit(10).collect(Collectors.toList()))
-                .stream()
-                .map(this::getResult)
-                .sorted()
-                .distinct()
-                .collect(Collectors.toList());
+        final List<Integer> returnedPorts = new ArrayList<Integer>();
+        for(int i = 0;i < ports.size(); i++) {
+            returnedPorts.add(provider.next());
+        }
 
         //then
         assertEquals(ports, returnedPorts);
@@ -44,24 +35,11 @@ public class PredefinedPortProviderTest {
         final PredefinedPortProvider provider = new PredefinedPortProvider(ports);
 
         //when
-        executor.invokeAll(
-                Stream.generate(() -> (Callable<Integer>) provider::next).limit(11).collect(Collectors.toList()))
-                .stream()
-                .map(this::getResult)
-                .sorted()
-                .distinct()
-                .collect(Collectors.toList());
+        for(int i = 0;i < ports.size(); i++) {
+            provider.next();
+        }
 
         //then exception should be thrown...
-    }
-
-    private int getResult(Future<Integer> f) {
-        int ret = 0;
-        try {
-            ret = f.get();
-        } catch (Exception e) {
-            throw new RedisBuildingException("failed to deliver", e);
-        }
-        return ret;
+        provider.next();
     }
 }

--- a/src/test/java/redis/embedded/ports/SequencePortProviderTest.java
+++ b/src/test/java/redis/embedded/ports/SequencePortProviderTest.java
@@ -2,44 +2,27 @@ package redis.embedded.ports;
 
 import org.junit.Test;
 
-import java.util.Comparator;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import static org.junit.Assert.assertEquals;
 
 public class SequencePortProviderTest {
-    private final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     @Test
-    public void nextShouldIncrementPortsConcurrently() throws Exception {
+    public void nextShouldIncrementPorts() throws Exception {
         //given
         final int startPort = 10;
+        final int portCount = 101;
         final SequencePortProvider provider = new SequencePortProvider(startPort);
 
         //when
-        final int max = executor.invokeAll(
-                Stream.generate(() -> (Callable<Integer>) provider::next).limit(101).collect(Collectors.toList()))
-                    .stream()
-                    .map(this::getResult)
-                    .max(Comparator.<Integer>naturalOrder())
-                    .get();
+        int max = 0;
+        for(int i = 0;i<portCount; i++) {
+            int port = provider.next();
+            if(port > max) {
+                max = port;
+            }
+        }
 
         //then
-        assertEquals(110, max);
-    }
-
-    private int getResult(Future<Integer> f) {
-        int ret = 0;
-        try {
-            ret = f.get();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return ret;
+        assertEquals(portCount + startPort - 1, max);
     }
 }


### PR DESCRIPTION
Previously JDK 8 features were used which limitted the project to those
supporting JDK 8. While some of the features being used are convenient,
none of the features were necessary.

Now the project supports JDK 6+ for those that are using older JDKs.

Fixes gh-38