### PR TITLE
Enable matching against multiple patterns to determine server readiness

### DIFF
--- a/src/main/java/redis/embedded/AbstractRedisInstance.java
+++ b/src/main/java/redis/embedded/AbstractRedisInstance.java
@@ -1,5 +1,6 @@
 package redis.embedded;
 
+import org.apache.commons.io.IOUtils;
 import redis.embedded.exceptions.EmbeddedRedisException;
 
 import java.io.*;
@@ -8,8 +9,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import org.apache.commons.io.IOUtils;
 
 abstract class AbstractRedisInstance implements Redis {
     protected List<String> args = Collections.emptyList();
@@ -61,13 +60,13 @@ abstract class AbstractRedisInstance implements Redis {
                     //Something goes wrong. Stream is ended before server was activated.
                     throw new RuntimeException("Can't start redis server. Check logs for details.");
                 }
-            } while (!outputLine.matches(redisReadyPattern()));
+            } while (!isReady(outputLine));
         } finally {
             IOUtils.closeQuietly(reader);
         }
     }
 
-    protected abstract String redisReadyPattern();
+    protected abstract boolean isReady(String outputLine);
 
     private ProcessBuilder createRedisProcessBuilder() {
         File executable = new File(args.get(0));

--- a/src/main/java/redis/embedded/RedisSentinel.java
+++ b/src/main/java/redis/embedded/RedisSentinel.java
@@ -13,8 +13,9 @@ public class RedisSentinel extends AbstractRedisInstance {
 
     public static RedisSentinelBuilder builder() { return new RedisSentinelBuilder(); }
 
+
     @Override
-    protected String redisReadyPattern() {
-        return REDIS_READY_PATTERN;
+    protected boolean isReady(String outputLine) {
+        return outputLine.matches(REDIS_READY_PATTERN);
     }
 }

--- a/src/main/java/redis/embedded/RedisServer.java
+++ b/src/main/java/redis/embedded/RedisServer.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 public class RedisServer extends AbstractRedisInstance {
     private static final String REDIS_READY_PATTERN = ".*The server is now ready to accept connections on port.*";
+    private static final String REDIS_4_READY_PATTERN = ".*Ready to accept connections.*";
     private static final int DEFAULT_REDIS_PORT = 6379;
 
     public RedisServer() throws IOException {
@@ -48,8 +49,9 @@ public class RedisServer extends AbstractRedisInstance {
         return new RedisServerBuilder();
     }
 
+
     @Override
-    protected String redisReadyPattern() {
-        return REDIS_READY_PATTERN;
+    protected boolean isReady(String outputLine) {
+        return outputLine.matches(REDIS_READY_PATTERN) || outputLine.matches(REDIS_4_READY_PATTERN);
     }
 }


### PR DESCRIPTION
Redis 4.x uses a different log line to indicate server readiness.  This change will allow multiple patterns to be used in readiness detection.