### PR TITLE
Not resetting redisConfigBuilder in RedisServerBuilder.

### DIFF
--- a/src/main/java/redis/embedded/RedisServerBuilder.java
+++ b/src/main/java/redis/embedded/RedisServerBuilder.java
@@ -72,8 +72,7 @@ public class RedisServerBuilder {
     }
 
     public void reset() {
-        this.executable = null;
-        this.redisConfigBuilder = null;
+        this.executable = null;        
         this.slaveOf = null;
         this.redisConf = null;
     }


### PR DESCRIPTION
Resetting redisConfigBuilder is forgetting settings which might have
been added by client by using withServerBuilder method on
RedisClusterBuilder. So it shouldn't be reset during master and slaves
creation.