### PR TITLE
Address already in use

### DIFF
--- a/src/main/java/redis/embedded/AbstractRedisInstance.java
+++ b/src/main/java/redis/embedded/AbstractRedisInstance.java
@@ -13,8 +13,11 @@ import org.apache.commons.io.IOUtils;
 
 abstract class AbstractRedisInstance implements Redis {
     protected List<String> args = Collections.emptyList();
+
     private volatile boolean active = false;
-	private Process redisProcess;
+
+    private Process redisProcess;
+
     private final int port;
 
     private ExecutorService executor;
@@ -28,7 +31,7 @@ abstract class AbstractRedisInstance implements Redis {
         return active;
     }
 
-	@Override
+    @Override
     public synchronized void start() throws EmbeddedRedisException {
         if (active) {
             throw new EmbeddedRedisException("This redis server instance is already running...");
@@ -55,11 +58,15 @@ abstract class AbstractRedisInstance implements Redis {
         BufferedReader reader = new BufferedReader(new InputStreamReader(redisProcess.getInputStream()));
         try {
             String outputLine;
+            StringBuilder output = new StringBuilder();
             do {
                 outputLine = reader.readLine();
                 if (outputLine == null) {
                     //Something goes wrong. Stream is ended before server was activated.
+                    System.out.println(output);
                     throw new RuntimeException("Can't start redis server. Check logs for details.");
+                } else {
+                    output.append(outputLine);
                 }
             } while (!outputLine.matches(redisReadyPattern()));
         } finally {


### PR DESCRIPTION
Hi there,

if you started and not stopped a test then the embedded redis is still running. During start of your next test the test fails with the only message
```
java.lang.RuntimeException: Can't start redis server. Check logs for details.
	at redis.embedded.AbstractRedisInstance.awaitRedisServerReady(AbstractRedisInstance.java:61)
	at redis.embedded.AbstractRedisInstance.start(AbstractRedisInstance.java:39)
	at redis.embedded.RedisServer.start(RedisServer.java:9)
[...]
```
I don't know if and where the logs are. I only see one binary
```
> l /tmp/1546964996223-0/ 
total 4180
drwxrwxr-x  2 stephan stephan    4096 Jan  8 17:29 .
drwxrwxrwt 32 root    root      32768 Jan  8 17:30 ..
-rwxrw-r--  1 stephan stephan 4236300 Jan  8 17:29 redis-server-2.8.19
```

I added printing the complete input. That would have helped me by printing
```
[5017] 08 Jan 18:13:47.548 # Creating Server TCP listening socket *:6379: bind: Address already in use
```
Though it's not like my other logs
```
18:13:47 INFO  org.springframework.boot.test.context.SpringBootTestContextBootstrapper - Using TestExecutionListeners ...
```