### PR TITLE
Allow changing the "readiness check" for different redis versions

### DIFF
--- a/src/main/java/redis/embedded/AbstractRedisInstance.java
+++ b/src/main/java/redis/embedded/AbstractRedisInstance.java
@@ -16,11 +16,13 @@ abstract class AbstractRedisInstance implements Redis {
     private volatile boolean active = false;
 	private Process redisProcess;
     private final int port;
+    private String redisReadyPattern;
 
     private ExecutorService executor;
 
-    protected AbstractRedisInstance(int port) {
+    protected AbstractRedisInstance(int port, String redisReadyPattern) {
         this.port = port;
+        this.redisReadyPattern = redisReadyPattern;
     }
 
     @Override
@@ -61,13 +63,11 @@ abstract class AbstractRedisInstance implements Redis {
                     //Something goes wrong. Stream is ended before server was activated.
                     throw new RuntimeException("Can't start redis server. Check logs for details.");
                 }
-            } while (!outputLine.matches(redisReadyPattern()));
+            } while (!outputLine.matches(redisReadyPattern));
         } finally {
             IOUtils.closeQuietly(reader);
         }
     }
-
-    protected abstract String redisReadyPattern();
 
     private ProcessBuilder createRedisProcessBuilder() {
         File executable = new File(args.get(0));

--- a/src/main/java/redis/embedded/RedisSentinel.java
+++ b/src/main/java/redis/embedded/RedisSentinel.java
@@ -4,17 +4,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RedisSentinel extends AbstractRedisInstance {
-    private static final String REDIS_READY_PATTERN = ".*Sentinel runid is.*";
+    static final String REDIS_SENTINEL_READY_PATTERN = ".*Sentinel runid is.*";
 
     public RedisSentinel(List<String> args, int port) {
-        super(port);
+        this(args, port, REDIS_SENTINEL_READY_PATTERN);
+    }
+
+    public RedisSentinel(List<String> args, int port, String readyPattern) {
+        super(port, readyPattern);
         this.args = new ArrayList<String>(args);
     }
 
     public static RedisSentinelBuilder builder() { return new RedisSentinelBuilder(); }
 
-    @Override
-    protected String redisReadyPattern() {
-        return REDIS_READY_PATTERN;
-    }
 }

--- a/src/main/java/redis/embedded/RedisSentinelBuilder.java
+++ b/src/main/java/redis/embedded/RedisSentinelBuilder.java
@@ -22,7 +22,8 @@ public class RedisSentinelBuilder {
     private File executable;
     private RedisExecProvider redisExecProvider = RedisExecProvider.defaultProvider();
     private Integer port = 26379;
-    private int masterPort = 6379;
+    private String readyPattern = RedisSentinel.REDIS_SENTINEL_READY_PATTERN;
+    private int masterPort = RedisServer.DEFAULT_REDIS_PORT;
     private String masterName = "mymaster";
     private long downAfterMilliseconds = 60000L;
     private long failoverTimeout = 180000L;
@@ -39,6 +40,11 @@ public class RedisSentinelBuilder {
 
     public RedisSentinelBuilder port(Integer port) {
         this.port = port;
+        return this;
+    }
+
+    public RedisSentinelBuilder readyPattern(String readyPattern) {
+        this.readyPattern = readyPattern;
         return this;
     }
 
@@ -97,7 +103,11 @@ public class RedisSentinelBuilder {
     public RedisSentinel build() {
         tryResolveConfAndExec();
         List<String> args = buildCommandArgs();
-        return new RedisSentinel(args, port);
+        if (this.readyPattern == null) {
+            return new RedisSentinel(args, port);
+        } else {
+            return new RedisSentinel(args, port, readyPattern);
+        }
     }
 
     private void tryResolveConfAndExec() {

--- a/src/main/java/redis/embedded/RedisServer.java
+++ b/src/main/java/redis/embedded/RedisServer.java
@@ -7,15 +7,15 @@ import java.util.Arrays;
 import java.util.List;
 
 public class RedisServer extends AbstractRedisInstance {
-    private static final String REDIS_READY_PATTERN = ".*The server is now ready to accept connections on port.*";
-    private static final int DEFAULT_REDIS_PORT = 6379;
+    static final String REDIS_STANDALONE_READY_PATTERN = ".*The server is now ready to accept connections on port.*";
+    static final int DEFAULT_REDIS_PORT = 6379;
 
     public RedisServer() throws IOException {
         this(DEFAULT_REDIS_PORT);
     }
 
     public RedisServer(int port) throws IOException {
-        super(port);
+        super(port, REDIS_STANDALONE_READY_PATTERN);
         File executable = RedisExecProvider.defaultProvider().get();
         this.args = Arrays.asList(
                 executable.getAbsolutePath(),
@@ -24,7 +24,7 @@ public class RedisServer extends AbstractRedisInstance {
 	}
 
     public RedisServer(File executable, int port) {
-        super(port);
+        super(port, REDIS_STANDALONE_READY_PATTERN);
         this.args = Arrays.asList(
                 executable.getAbsolutePath(),
                 "--port", Integer.toString(port)
@@ -32,15 +32,19 @@ public class RedisServer extends AbstractRedisInstance {
     }
 
     public RedisServer(RedisExecProvider redisExecProvider, int port) throws IOException {
-        super(port);
+        super(port, REDIS_STANDALONE_READY_PATTERN);
         this.args = Arrays.asList(
                 redisExecProvider.get().getAbsolutePath(),
                 "--port", Integer.toString(port)
         );
     }
 
-    RedisServer(List<String> args, int port) {
-        super(port);
+    public RedisServer(List<String> args, int port) {
+        this(args, port, REDIS_STANDALONE_READY_PATTERN);
+    }
+
+    public RedisServer(List<String> args, int port, String readyPattern) {
+        super(port, readyPattern);
         this.args = new ArrayList<String>(args);
     }
 
@@ -48,8 +52,4 @@ public class RedisServer extends AbstractRedisInstance {
         return new RedisServerBuilder();
     }
 
-    @Override
-    protected String redisReadyPattern() {
-        return REDIS_READY_PATTERN;
-    }
 }

--- a/src/main/java/redis/embedded/RedisServerBuilder.java
+++ b/src/main/java/redis/embedded/RedisServerBuilder.java
@@ -17,7 +17,8 @@ public class RedisServerBuilder {
 
     private File executable;
     private RedisExecProvider redisExecProvider = RedisExecProvider.defaultProvider();
-    private int port = 6379;
+    private int port = RedisServer.DEFAULT_REDIS_PORT;
+    private String readyPattern = RedisServer.REDIS_STANDALONE_READY_PATTERN;
     private InetSocketAddress slaveOf;
     private String redisConf;
 
@@ -30,6 +31,11 @@ public class RedisServerBuilder {
 
     public RedisServerBuilder port(int port) {
         this.port = port;
+        return this;
+    }
+
+    public RedisServerBuilder readyPattern(String readyPattern) {
+        this.readyPattern = readyPattern;
         return this;
     }
 
@@ -68,7 +74,7 @@ public class RedisServerBuilder {
     public RedisServer build() {
         tryResolveConfAndExec();
         List<String> args = buildCommandArgs();
-        return new RedisServer(args, port);
+        return new RedisServer(args, port, readyPattern);
     }
 
     public void reset() {


### PR DESCRIPTION
Different versions of Redis have different startup outputs. The currently implemented readiness check works for Redis 2.8.19 but not for Redis 4.0.4 nor 5.0.5.

Redis 5.0.5 standalone output
```
73261:M 23 May 2019 17:40:38.542 * Ready to accept connections
```
Redis 5.0.5 sentinel output
```
73460:X 23 May 2019 17:43:28.517 # Sentinel ID is 0beaec56384551b5258545a5f41cba769a01d4f1
```

When defining a different redis executable (`RedisExecProvider`)  it should be possible to override the *REDIS_READY_PATTEN*