### PR TITLE
Add support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
 jdk:
   - oraclejdk8
+addon:
+  apt:
+    packages:
+      - libjemalloc-dev
 cache:
   directories:
   - $HOME/.m2

--- a/src/main/java/redis/embedded/RedisExecProvider.java
+++ b/src/main/java/redis/embedded/RedisExecProvider.java
@@ -32,6 +32,8 @@ public class RedisExecProvider {
 
         executables.put(OsArchitecture.MAC_OS_X_x86, "redis-server-2.8.19.app");
         executables.put(OsArchitecture.MAC_OS_X_x86_64, "redis-server-2.8.19.app");
+
+        executables.put(OsArchitecture.UNIX_PPC64LE, "redis-server-3.2.8-ppc64le");
     }
 
     public RedisExecProvider override(OS os, String executable) {

--- a/src/main/java/redis/embedded/RedisSentinel.java
+++ b/src/main/java/redis/embedded/RedisSentinel.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RedisSentinel extends AbstractRedisInstance {
-    private static final String REDIS_READY_PATTERN = ".*Sentinel runid is.*";
+    private static final String REDIS_READY_PATTERN = ".*Sentinel (run)?((?i)id) is.*";
 
     public RedisSentinel(List<String> args, int port) {
         super(port);

--- a/src/main/java/redis/embedded/util/Architecture.java
+++ b/src/main/java/redis/embedded/util/Architecture.java
@@ -2,5 +2,6 @@ package redis.embedded.util;
 
 public enum Architecture {
     x86,
-    x86_64
+    x86_64,
+    ppc64le
 }

--- a/src/main/java/redis/embedded/util/OSDetector.java
+++ b/src/main/java/redis/embedded/util/OSDetector.java
@@ -54,7 +54,9 @@ public class OSDetector {
             input = new BufferedReader(new InputStreamReader(proc.getInputStream()));
             while ((line = input.readLine()) != null) {
                 if (line.length() > 0) {
-                    if (line.contains("64")) {
+                    if (line.equals("ppc64le")) {
+                        return Architecture.ppc64le;
+                    } else if (line.contains("64")) {
                         return Architecture.x86_64;
                     }
                 }

--- a/src/main/java/redis/embedded/util/OsArchitecture.java
+++ b/src/main/java/redis/embedded/util/OsArchitecture.java
@@ -13,6 +13,8 @@ public class OsArchitecture {
     public static final OsArchitecture MAC_OS_X_x86 = new OsArchitecture(OS.MAC_OS_X, Architecture.x86);
     public static final OsArchitecture MAC_OS_X_x86_64 = new OsArchitecture(OS.MAC_OS_X, Architecture.x86_64);
 
+    public static final OsArchitecture UNIX_PPC64LE = new OsArchitecture(OS.UNIX, Architecture.ppc64le);
+
     private final OS os;
     private final Architecture arch;
     

--- a/src/test/java/redis/embedded/RedisServerTest.java
+++ b/src/test/java/redis/embedded/RedisServerTest.java
@@ -97,7 +97,8 @@ public class RedisServerTest {
                 .override(OS.UNIX, Architecture.x86_64, Resources.getResource("redis-server-2.8.19").getFile())
                 .override(OS.WINDOWS, Architecture.x86, Resources.getResource("redis-server-2.8.19.exe").getFile())
                 .override(OS.WINDOWS, Architecture.x86_64, Resources.getResource("redis-server-2.8.19.exe").getFile())
-                .override(OS.MAC_OS_X, Resources.getResource("redis-server-2.8.19").getFile());
+                .override(OS.MAC_OS_X, Resources.getResource("redis-server-2.8.19").getFile())
+                .override(OS.UNIX, Architecture.ppc64le, Resources.getResource("redis-server-3.2.8-ppc64le").getFile());
         
         redisServer = new RedisServerBuilder()
                 .redisExecProvider(customProvider)


### PR DESCRIPTION
Validated using redis-server binary extracted from
the following rpm and copying it to resources dir
with name redis-server-3.2.8-ppc64le:
https://cbs.centos.org/kojifiles/packages/redis/3.2.8/1.el7/ppc64le/redis-3.2.8-1.el7.ppc64le.rpm

Note: the binary is not part of the commit. It can be added to the repo with the following steps:
mkdir redis_rpm; cd redis_rpm
wget https://cbs.centos.org/kojifiles/packages/redis/3.2.8/1.el7/ppc64le/redis-3.2.8-1.el7.ppc64le.rpm
rpm2cpio redis-3.2.8-1.el7.ppc64le.rpm | cpio -idm
cd ..; git clone https://github.com/kstyrc/embedded-redis.git
cp redis_rpm/usr/bin/redis-server embedded-redis/src/main/resources/redis-server-3.2.8-ppc64le

Fixes https://github.com/kstyrc/embedded-redis/issues/71