### PR TITLE
The temporary directory does not exist.

### DIFF
--- a/src/main/java/redis/embedded/util/JarUtil.java
+++ b/src/main/java/redis/embedded/util/JarUtil.java
@@ -10,6 +10,11 @@ import java.io.IOException;
 public class JarUtil {
 
     public static File extractExecutableFromJar(String executable) throws IOException {
+        // To begin with, you need to check if the temporary directory exists. If it doesn't exist, create the temporary directory first.
+        File baseDir = new File(System.getProperty("java.io.tmpdir"));
+        if (!baseDir.exists()) {
+            baseDir.mkdirs();
+        }
         File tmpDir = Files.createTempDir();
         tmpDir.deleteOnExit();
 


### PR DESCRIPTION
To resolve the issue of the service failing to start due to the nonexistence of the temporary directory